### PR TITLE
use tags from options when sending json

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ Humio.prototype.sendJson = function(json, options) {
 
   var requestBody = [
     {
-      "tags": {},
+      "tags": options.tags || {},
       "events": [
         {
           "attributes": sentFields,


### PR DESCRIPTION
This PR solves issue https://github.com/humio/humio-js/issues/3
(custom tags are ignored when sending json and empty tags object is sent instead).

The fix is to get tags from options instead.